### PR TITLE
WIP: Display Errors

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -48,7 +48,15 @@ type Copyable
   Copyable(view, text::String) = new(view, limit(text))
 end
 
-Copyable(view, text) = Copyable(view, render(Clipboard(), text))
+function Copyable(view, text)
+  cp = try
+    render(Clipboard(), text)
+  catch e
+    sprint(showerror, e, catch_backtrace())
+  end
+  Copyable(view, cp)
+end
+
 Copyable(view) = Copyable(view, view)
 
 immutable Link


### PR DESCRIPTION
This is a long-standing issue, and a frustrating one if you're developing a type with a tricky display method. So let's fix that.

For now I just have a catch for clipboard errors. Fixing the regular display will probably be as simple as having some `rendererr(display, x)` function which renders a `DisplayError` on failure.
