### PR TITLE
RFC: Eval into JunoMain by default

### DIFF
--- a/src/Juno.jl
+++ b/src/Juno.jl
@@ -39,4 +39,9 @@ if VERSION >= v"0.5-"
   include("base/base.jl")
 end
 
+function startup(port)
+  eval(Main, :(module JunoMain; using $(VERSION < v"0.5-" ? :Atom : :Juno); end))
+  Juno.connect(port)
+end
+
 end # module

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -1,4 +1,4 @@
-export selector, input, structure
+export selector, input, structure, clearall
 
 """
     selector([xs...]) -> x
@@ -36,6 +36,18 @@ Get the size of Juno's plot pane in `px`. Does not yet have a fallback for
 other environments.
 """
 plotsize() = Atom.plotsize()
+
+"""
+    clearall()
+
+Reload the `JunoMain` module when running inside of Juno, and falls back to
+`workspace()` otherwise.
+"""
+function clearall()
+  isactive() ? eval(Main, :(module JunoMain; using $(VERSION < v"0.5-" ? :Atom : :Juno); end)) :
+               workspace()
+  nothing
+end
 
 """
     structure(x)

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -44,8 +44,7 @@ Reload the `JunoMain` module when running inside of Juno, and falls back to
 `workspace()` otherwise.
 """
 function clearall()
-  isactive() ? eval(Main, :(module JunoMain; using $(VERSION < v"0.5-" ? :Atom : :Juno); end)) :
-               workspace()
+  isactive() ? Atom.resetJunoMain() : workspace()
   nothing
 end
 


### PR DESCRIPTION
This allows us to implement something akin to `workspace()` for the `JunoMain` module (namely the `clearall()` function here and a `Reset Workspace` in Atom).

I think these PRs are fairly comprehensive, but maybe there's some general problem with this approach that I don't know of -- have only tested this for a bit.

Let me know what you think!