### PR TITLE
use Main.Atom instead of Atom

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -5,13 +5,13 @@ export @enter, breakpoint
 Step into the function call in `ex`.
 """
 macro enter(ex)
-  Atom.enter(ex)
+  Main.Atom.enter(ex)
 end
 
-breakpoint(args...) = Atom.breakpoint(args...)
+breakpoint(args...) = Main.Atom.breakpoint(args...)
 
 function connect(args...; kws...)
   activate()
-  eval(:(Atom.connect($args...; $kws...)))
+  eval(:(Main.Atom.connect($args...; $kws...)))
   return
 end


### PR DESCRIPTION
un-breaks these calls in 0.7, so long as  gets called first.

FMI, see #127.