### PR TITLE
Progress bar: multiple iteration variables & comprehensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7-beta2
+julia 0.7
 Media

--- a/src/Juno.jl
+++ b/src/Juno.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module Juno
 
 using Media, Base64, Profile

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -99,7 +99,7 @@ function _progress(name, thresh, ex, target, result, iter_vars, ranges, body)
   quote
     if isactive()
       @logmsg($PROGRESSLEVEL, $name, progress=0.0, _id=Symbol($_id))
-      try
+      $target = try
         ranges = $(Expr(:vect,ranges...))
         nranges = length(ranges)
         lens = length.(ranges)
@@ -108,7 +108,7 @@ function _progress(name, thresh, ex, target, result, iter_vars, ranges, body)
         _frac(i) = (sum((i-1)*s for (i,s) in zip(i,strides)) + 1) / n
         lastfrac = 0.0
 
-        $target = $(Expr(:comprehension, Expr(:generator,
+        $(Expr(:comprehension, Expr(:generator,
                             quote
                               frac = _frac($(Expr(:vect, count_vars...)))
                               if frac - lastfrac > $thresh
@@ -119,10 +119,10 @@ function _progress(name, thresh, ex, target, result, iter_vars, ranges, body)
                             end,
                             iter_exprs...
                          )))
-        $result
       finally
         @logmsg($PROGRESSLEVEL, $name, progress="done", _id=Symbol($_id))
       end
+      $result
     else
       $(esc(ex))
     end

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -91,9 +91,9 @@ function _progress(name, thresh, ex)
 end
 
 function _progress(name, thresh, ex, target, retval, iter_vars, ranges, body)
-  iter_exprs = [:(($(Symbol("i$k")),$(esc(v))) = enumerate($(esc(r))))
-                  for (k,(v,r)) in enumerate(zip(iter_vars,ranges))]
-  var_array_ex = Expr(:vect, (esc(v) for v in iter_vars)...)
+  count_vars = [Symbol("i$k") for k=1:length(iter_vars)]
+  iter_exprs = [:(($i,$(esc(v))) = enumerate($(esc(r))))
+                  for (i,v,r) in zip(count_vars,iter_vars,ranges)]
   _id = "progress_$(gensym())"
   quote
     if isactive()
@@ -116,7 +116,7 @@ function _progress(name, thresh, ex, target, retval, iter_vars, ranges, body)
 
         $target = $(Expr(:comprehension, Expr(:generator,
                             quote
-                              lastfrac = _update(_frac($var_array_ex),lastfrac)
+                              lastfrac = _update(_frac($(Expr(:vect, count_vars...))),lastfrac)
                               $body
                             end,
                             iter_exprs...

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -39,10 +39,12 @@ function progress(f; name = "")
 end
 
 """
-    @progress [name="", threshold=0.005] for i = ...
+    @progress [name="", threshold=0.005] for i = ..., j = ..., ...
+    @progress [name="", threshold=0.005] x = [... for i = ..., j = ..., ...]
 
-Show a progress meter named `name` for the given loop if possible. Update frequency
-is limited by `threshold` (one update per 0.5% of progress by default).
+Show a progress meter named `name` for the given loop or array comprehension
+if possible. Update frequency is limited by `threshold` (one update per 0.5% of
+progress by default).
 """
 macro progress(args...)
   _progress(args...)
@@ -53,37 +55,78 @@ _progress(name::AbstractString, ex) = _progress(name, 0.005, ex)
 _progress(thresh::Real, ex) = _progress("", thresh, ex)
 
 function _progress(name, thresh, ex)
-  if ex.head == :for &&
-     ex.args[1].head == Symbol("=") &&
-     ex.args[2].head == :block
-    x = esc(ex.args[1].args[1])
-    range = esc(ex.args[1].args[2])
+  if ex.head == Symbol("=") &&
+        ex.args[2].head == :comprehension &&
+        ex.args[2].args[1].head == :generator
+    # comprehension: <target> = [<body> for <iter_var> in <range>,...]
+    target = esc(ex.args[1])
+    retval = target
+    gen_ex = ex.args[2].args[1]
+    body = esc(gen_ex.args[1])
+    iter_exprs = gen_ex.args[2:end]
+    iter_vars = [e.args[1] for e in iter_exprs]
+    ranges = [e.args[2] for e in iter_exprs]
+  elseif ex.head == :for &&
+        ex.args[1].head == Symbol("=") &&
+        ex.args[2].head == :block
+    # single-variable for: for <iter_var> = <range>; <body> end
+    target = :_
+    retval = :nothing
+    iter_vars = [ex.args[1].args[1]]
+    ranges = [ex.args[1].args[2]]
     body = esc(ex.args[2])
-    _id = "progress_$(gensym())"
-    quote
-      if isactive()
-        @logmsg($PROGRESSLEVEL, $name, progress=0.0, _id=Symbol($_id))
-        try
-          lastfrac = 0.0
-          range = $range
-          n = length(range)
-          for (i, $x) in enumerate(range)
-            $body
-
-            frac = i/n
-            if frac - lastfrac > $thresh
-              @logmsg($PROGRESSLEVEL, $name, progress=frac, _id=Symbol($_id))
-              lastfrac = frac
-            end
-          end
-        finally
-          @logmsg($PROGRESSLEVEL, $name, progress="done", _id=Symbol($_id))
-        end
-      else
-        $(esc(ex))
-      end
-    end
+  elseif ex.head == :for &&
+        ex.args[1].head == :block &&
+        ex.args[2].head == :block
+    # multi-variable for: for <iter_var> = <range>,...; <body> end
+    target = :_
+    retval = :nothing
+    iter_vars = [e.args[1] for e in ex.args[1].args]
+    ranges = [e.args[2] for e in ex.args[1].args]
+    body = esc(ex.args[2])
   else
-    error("@progress requires a for loop")
+    error("@progress requires a for loop or comprehension with assignment")
+  end
+  _progress(name, thresh, ex, target, retval, iter_vars, ranges, body)
+end
+
+function _progress(name, thresh, ex, target, retval, iter_vars, ranges, body)
+  iter_exprs = [:(($(Symbol("i$k")),$(esc(v))) = enumerate($(esc(r))))
+                  for (k,(v,r)) in enumerate(zip(iter_vars,ranges))]
+  var_array_ex = Expr(:vect, (esc(v) for v in iter_vars)...)
+  _id = "progress_$(gensym())"
+  quote
+    if isactive()
+      @logmsg($PROGRESSLEVEL, $name, progress=0.0, _id=Symbol($_id))
+      try
+        ranges = $(Expr(:vect,ranges...))
+        nranges = length(ranges)
+        lens = length.(ranges)
+        n = prod(lens)
+        strides = cumprod([1;lens[1:end-1]])
+        _frac(i) = (sum((i-1)*s for (i,s) in zip(i,strides)) + 1) / n
+        lastfrac = 0.0
+        function _update(frac,lastfrac)
+          if frac - lastfrac > $thresh
+            @logmsg($PROGRESSLEVEL, $name, progress=frac, _id=Symbol($_id))
+            lastfrac = frac
+          end
+          lastfrac
+        end
+
+        $target = $(Expr(:comprehension, Expr(:generator,
+                            quote
+                              lastfrac = _update(_frac($var_array_ex),lastfrac)
+                              $body
+                            end,
+                            iter_exprs...
+                         )))
+        $retval
+      finally
+        @logmsg($PROGRESSLEVEL, $name, progress="done", _id=Symbol($_id))
+      end
+    else
+      $(esc(ex))
+    end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,18 +7,34 @@ using Test
 
 @test_throws Exception selector(["foo", "bar", "baz"])
 
-let i = 0
-  @progress for _ = 1:100
+let i = 0, x
+  x = @progress for _ = 1:100
     i += 1
   end
   @test i == 100
+  @test x == nothing
 end
 
-let i = 0
-  @progress "named" for _ = 1:100
+let i = 0, x
+  x = @progress "named" for _ = 1:100
     i += 1
   end
   @test i == 100
+  @test x == nothing
 end
+
+let i = 0, j = 0, x
+  x = @progress for _ = 1:10, __ = 1:20
+    i += 1
+  end
+  @test i == 200
+end
+
+let x,y
+  x = @progress y = [i+3j for i=1:3, j=1:4]
+  @test y == reshape(4:15,3,4)
+  @test x == y
+end
+
 
 @test Juno.notify("hi") == nothing


### PR DESCRIPTION
Support for multiple variables & array comprehensions in the `@progress` macro, e.g.,
```
@progress for i = 1:10, j = 1:10; 
   f(i,j)
end

@progress x = [f(i,j) for i=1:10, j=1:10]
```

This PR is based of version 0.4.1, since I couldn't get Atom to run with Julia 0.7 beta so far. Hopefully it shouldn't be too difficult to merge, but if it's a problem I won't mind waiting for 0.7 support in Atom to stabilize and open a new PR later instead of this one.