### PR TITLE
Use LogLevel for PROGRESSLEVEL

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -1,8 +1,8 @@
 export @progress
 
-using Logging: @logmsg
+using Logging: @logmsg, LogLevel
 
-const PROGRESSLEVEL = -1
+const PROGRESSLEVEL = LogLevel(-1)
 
 """
     progress(f::Function; name = "", msg = "")


### PR DESCRIPTION
According to https://docs.julialang.org/en/latest/stdlib/Logging/#Logging.@logmsg, an integer is not a correct argument to use.

ref: https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/510